### PR TITLE
supress max_iter warning  when reducing to single scenario

### DIFF
--- a/sgr_tools/ScenarioReduction/ScenarioTree.py
+++ b/sgr_tools/ScenarioReduction/ScenarioTree.py
@@ -2,6 +2,7 @@ import numpy as np
 from typing import Any, List
 from sklearn_extra.cluster import KMedoids
 import logging
+import warnings
 from . import NonAnticipativitySets
 
 logger = logging.getLogger(__name__)
@@ -242,7 +243,10 @@ class ScenarioTree:
     def _reduce_to_one_scenario(self) -> None:
         """Reduce scenario tree to one scenario."""
         logging.debug("Reducing %s into to one scenario...", self)
-        clustering = self._cluster_scenarios(data=self._data, n_scenarios=1)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="n_clusters should be larger than 2 if max_iter != 0 setting max_iter to 0.")
+            clustering = self._cluster_scenarios(data=self._data, n_scenarios=1)
         self._data = clustering.cluster_centers_
         logging.debug("Update tree data to array of shape %s", self._data.shape)
         self.is_reduced = True
@@ -256,7 +260,7 @@ class ScenarioTree:
         """
 
         # K-Medoids
-        clustering = KMedoids(metric="euclidean", n_clusters=n_scenarios, random_state=self._seed, method='pam').fit(data)
+        clustering = KMedoids(metric="euclidean", n_clusters=n_scenarios, random_state=self._seed, method='pam', max_iter=0).fit(data)
         # Scenario probability is ratio of scenario points in cluster
         clustering.probs = (
             np.array(

--- a/sgr_tools/ScenarioReduction/ScenarioTree.py
+++ b/sgr_tools/ScenarioReduction/ScenarioTree.py
@@ -260,7 +260,7 @@ class ScenarioTree:
         """
 
         # K-Medoids
-        clustering = KMedoids(metric="euclidean", n_clusters=n_scenarios, random_state=self._seed, method='pam', max_iter=0).fit(data)
+        clustering = KMedoids(metric="euclidean", n_clusters=n_scenarios, random_state=self._seed, method='pam').fit(data)
         # Scenario probability is ratio of scenario points in cluster
         clustering.probs = (
             np.array(


### PR DESCRIPTION
Fixes #2 by suppressing the max_iter warning when reducing to single scenario.
